### PR TITLE
[TASK] Output slug in FAQ model

### DIFF
--- a/Classes/Domain/Model/Faq.php
+++ b/Classes/Domain/Model/Faq.php
@@ -25,6 +25,7 @@ class Faq extends AbstractEntity
     protected string $question = '';
     protected string $answer = '';
     protected string $keywords = '';
+    protected string $slug = '';
 
     /**
      * @var ObjectStorage<Category>
@@ -96,6 +97,16 @@ class Faq extends AbstractEntity
     public function setKeywords(string $keywords): void
     {
         $this->keywords = $keywords;
+    }
+
+    public function getSlug(): string
+    {
+        return $this->slug;
+    }
+
+    public function setSlug(string $slug): void
+    {
+        $this->slug = $slug;
     }
 
     public function addImage(FileReference $image): void


### PR DESCRIPTION
Somehow the slug wasn't available yet in the FAQ model but everything else was there (TCA, SQL column). Was this on purpose?

Well, I thought it's a good idea to output this information when it is persisted already. :)